### PR TITLE
Added back previous get blocks function

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -42,9 +42,7 @@ export const GET_BLOCK = gql`
 export const GET_BLOCKS = (timestamps) => {
   let queryString = "query blocks {";
   queryString += timestamps.map((timestamp) => {
-    return `t${timestamp}:blocks(first: 1, orderBy: timestamp, orderDirection: desc, where: { timestamp_gt: ${timestamp}, timestamp_lt: ${
-        timestamp + 600
-    } }) {
+    return `t${timestamp}:blocks(first: 1, orderBy: number, orderDirection: asc, where: { timestamp_gt: ${timestamp} }) {
       number
     }`;
   });

--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -42,7 +42,9 @@ export const GET_BLOCK = gql`
 export const GET_BLOCKS = (timestamps) => {
   let queryString = "query blocks {";
   queryString += timestamps.map((timestamp) => {
-    return `t${timestamp}:blocks(first: 1, orderBy: timestamp, orderDirection: desc, where: { timestamp_gt: ${timestamp} }) {
+    return `t${timestamp}:blocks(first: 1, orderBy: timestamp, orderDirection: desc, where: { timestamp_gt: ${timestamp}, timestamp_lt: ${
+        timestamp + 600
+    } }) {
       number
     }`;
   });


### PR DESCRIPTION
- Seems that because this timestamp_lt query param was removed it didn't fetch block data properly. Is there a reason for removing it? And should I look more into it?
```
  timestamp_lt: ${
        timestamp + 600
```